### PR TITLE
Update ROS

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ me with an NVIDIA GPU:
     ros2 run carla_camera_publisher carla_camera_publisher localhost 2000 --ros-args \
         -p width:=1920 -p height:=1080 \
         -p carla_camera_publisher.camera.foxglove.encoding:=h264_nvenc \
-        -p carla_camera_publisher.camera.foxglove.preset:=p4 \
-        -p carla_camera_publisher.camera.foxglove.tune:=ll \
+        -p carla_camera_publisher.camera.foxglove.encoder_av_options:="preset:fast,tune:zerolatency" \
         -p carla_camera_publisher.camera.foxglove.bit_rate:=30000000
 
 To see the video in Foxglove run:
@@ -132,8 +131,7 @@ video encoding):
     ros2 run carla_camera_publisher carla_camera_publisher localhost 2000 --ros-args \
         -p width:=1920 -p height:=1080 \
         -p carla_camera_publisher.camera.ffmpeg.encoding:=h264_nvenc \
-        -p carla_camera_publisher.camera.ffmpeg.preset:=p4 \
-        -p carla_camera_publisher.camera.ffmpeg.tune:=ll \
+        -p carla_camera_publisher.camera.ffmpeg.encoder_av_options:="preset:fast,tune:zerolatency" \
         -p carla_camera_publisher.camera.ffmpeg.bit_rate:=30000000
 
 Record the compressed video to a ROS bag:

--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743964225,
-        "narHash": "sha256-kNnEsx0vIlttxIBImExRihb5kzIZltoDY60W61igjVc=",
+        "lastModified": 1765614839,
+        "narHash": "sha256-2eC5GsOlQyfkZTaZ0UzMEL64FZXudjvOcpnvM/3DvFw=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "2985461e1ca758fb0c9ad90dbeaa3e46b652e15c",
+        "rev": "51144d349de66dd00216d2cfade1bf86692ba4f4",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739580444,
-        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
-        "owner": "lopsided98",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This updates ROS version that we use via Nix from 2025-04 to 2025-12. Parameters of `ffmpeg_image_transport` in example commands had to be changed.